### PR TITLE
Launch files fix

### DIFF
--- a/ros/launch/hsr_qt_tablet_interface.launch
+++ b/ros/launch/hsr_qt_tablet_interface.launch
@@ -1,8 +1,8 @@
 <launch>
-    <arg name="qt_id" value="qt" />
-    <arg name="robot_id" value="hsr" />
-    <arg name="zyre_network_interface" value="wlp3s0" />
-    <arg name="say_topic" value="/say" />
+    <arg name="qt_id" default="qt" />
+    <arg name="robot_id" default="hsr" />
+    <arg name="zyre_network_interface" default="wlp3s0" />
+    <arg name="say_topic" default="/say" />
 
     <node name="hsr_qt_tablet_interface" pkg="mas_qt_tablet_interface" type="robot_qt_tablet_interface" output="screen">
         <param name="qt_id" value="$(arg qt_id)" />

--- a/ros/launch/nao_qt_tablet_interface.launch
+++ b/ros/launch/nao_qt_tablet_interface.launch
@@ -1,7 +1,7 @@
 <launch>
-    <arg name="qt_id" value="qt" />
-    <arg name="robot_id" value="nao" />
-    <arg name="zyre_network_interface" value="wlan0" />
+    <arg name="qt_id" default="qt" />
+    <arg name="robot_id" default="nao" />
+    <arg name="zyre_network_interface" default="wlan0" />
 
     <node name="nao_qt_tablet_interface" pkg="mas_qt_tablet_interface" type="nao_qt_tablet_interface" output="screen">
         <param name="qt_id" value="$(arg qt_id)" />

--- a/ros/launch/qt_tablet_interface.launch
+++ b/ros/launch/qt_tablet_interface.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="qt_id" value="qt" />
-    <arg name="robot_id" value="hsr" />
-    <arg name="zyre_network_interface" value="wlp59s0" />
+    <arg name="robot_id" value="nao" />
+    <arg name="zyre_network_interface" value="wlp0s20f3" />
 
     <node name="qt_tablet_interface" pkg="mas_qt_tablet_interface" type="qt_tablet_interface" output="screen">
         <param name="qt_id" value="$(arg qt_id)" />

--- a/ros/launch/qt_tablet_interface.launch
+++ b/ros/launch/qt_tablet_interface.launch
@@ -1,7 +1,7 @@
 <launch>
-    <arg name="qt_id" value="qt" />
-    <arg name="robot_id" value="nao" />
-    <arg name="zyre_network_interface" value="wlp0s20f3" />
+    <arg name="qt_id" default="qt" />
+    <arg name="robot_id" default="nao" />
+    <arg name="zyre_network_interface" default="wlp0s20f3" />
 
     <node name="qt_tablet_interface" pkg="mas_qt_tablet_interface" type="qt_tablet_interface" output="screen">
         <param name="qt_id" value="$(arg qt_id)" />


### PR DESCRIPTION
* Changed the name of the robot_id in qt_tablet_interface.launch from hsr to nao (to be compatible with nao_qt_tablet_interface.launch)
* Changed the types of the args so that they can be overriden by a command-line argument (required for docker compose).